### PR TITLE
update: Fix edge case of apos followed by string literal

### DIFF
--- a/src/JsonURL.js
+++ b/src/JsonURL.js
@@ -90,6 +90,7 @@ const ERR_MSG_EXTRACHARS = "JSON->URL: unexpected text after composite";
 const ERR_MSG_LIMIT_MAXCHARS = "JSON->URL: MaxParseChars exceeded";
 const ERR_MSG_LIMIT_MAXDEPTH = "JSON->URL: MaxParseDepth exceeded";
 const ERR_MSG_LIMIT_MAXVALUES = "JSON->URL: MaxParseValues exceeded";
+const ERR_MSG_EXPECT_QUOTE = "JSON->URL: quoted string still open";
 
 function parseDigitsLength(text, i, len) {
   var ret = 0;
@@ -265,6 +266,10 @@ function parseLiteralLength(text, i, end, errmsg) {
       default:
         throw new SyntaxError(errorMessage(ERR_MSG_BADCHAR, i));
     }
+  }
+
+  if (isQuote) {
+    throw new SyntaxError(errorMessage(ERR_MSG_EXPECT_QUOTE, i));
   }
 
   return end;

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -56,6 +56,7 @@ test.each([
   "(a=b)",
   "'a=b'",
   "'a&b'",
+  "'hello",
 ])("JsonURL.parse(%p)", (text) => {
   const u = new JsonURL();
 

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -55,6 +55,7 @@ test.each([
   ["a,b", "'a,b'"],
   ["a,b c", "'a,b+c'"],
   ["Bob & Frank", "Bob+%26+Frank"],
+  ["'hello", "%27hello"],
 ])("JsonURL.stringify(%p)", (value, expected) => {
   expect(JsonURL.stringify(value)).toBe(expected);
 });


### PR DESCRIPTION
Both parse() and stringify() failed to properly handle an apos followed
by a string literal, e.g 'hello.

This commit fixes both, and adds a test case.