### PR TITLE
fix: Bug when encoding more than one left/right paren in string literal

### DIFF
--- a/src/JsonURL.js
+++ b/src/JsonURL.js
@@ -27,6 +27,10 @@
 
 const rx_decode_space = /\+/g;
 const rx_encode_pctspace = /%20/g;
+const rx_encode_comma = /,/g;
+const rx_encode_colon = /:/g;
+const rx_encode_lparen = /\(/g;
+const rx_encode_rparen = /\)/g;
 const rx_encode_space = / /g;
 
 //
@@ -289,10 +293,10 @@ function parseStringLiteral(text, pos, end, removeQuotes) {
 function encodeStringLiteral(text) {
   let ret = encodeURIComponent(text);
   ret = ret.replace(rx_encode_pctspace, "+");
-  ret = ret.replace(",", "%x2C");
-  ret = ret.replace(":", "%x3A");
-  ret = ret.replace("(", "%x28");
-  ret = ret.replace(")", "%x29");
+  ret = ret.replace(rx_encode_comma, "%x2C");
+  ret = ret.replace(rx_encode_colon, "%x3A");
+  ret = ret.replace(rx_encode_lparen, "%x28");
+  ret = ret.replace(rx_encode_rparen, "%x29");
 
   return ret;
 }

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -54,6 +54,12 @@ test.each([
   ["a b c", "a+b+c", "a+b+c"],
   ["a,b", "'a,b'", "a%2Cb"],
   ["a,b c", "'a,b+c'", "a%2Cb+c"],
+  ["a,b,c", "'a,b,c'", "a%2Cb%2Cc"],
+  ["a:b:c", "'a:b:c'", "a%3Ab%3Ac"],
+  ["((()))", "'((()))'", "%x28%x28%x28%x29%x29%x29"],
+  [":::", "':::'", "%3A%3A%3A"],
+  [",,,", "',,,'", "%2C%2C%2C"],
+  ["   ", "+++", "+++"],
   ["Bob & Frank", "Bob+%26+Frank", "Bob+%26+Frank"],
   ["'hello", "%27hello", "'hello"],
 ])("JsonURL.stringify(%p)", (value, expected, expectedISL) => {


### PR DESCRIPTION
Per the docs, String.replace(target,dest) will only replace the first
occurrence when target is a string. A regex is needed to do a global
search and replace.

One odd thing I found when testing is that these worked, and replaced
all occurrences:
   ret.replace(",", "%x2C")
   ret.replace(":", "%x3A")

But these did not, and requred a regex to get all occurrences:
  ret.replace("(", "%x28")
  ret.replace(")", "%x28")

I used a regex for all regardless.