### PR TITLE
feat: Add support for empty keys and empty string values

### DIFF
--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -57,6 +57,9 @@ test.each([
   "'a=b'",
   "'a&b'",
   "'hello",
+  "(a:)",
+  "(:a)",
+  "(a,,c)",
 ])("JsonURL.parse(%p)", (text) => {
   const u = new JsonURL();
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -75,6 +75,18 @@ test.each([
   );
 });
 
+test.each([
+  ["(a,,c)", { allowEmptyUnquotedValues: true }, ["a", "", "c"]],
+  [
+    "(a:,:d,e:f)",
+    { allowEmptyUnquotedKeys: true, allowEmptyUnquotedValues: true },
+    { a: "", "": "d", e: "f" },
+  ],
+])("JsonURL.parse(%s)", (text, options, expected) => {
+  expect(u.parse(text, options)).toEqual(expected);
+  expect(JsonURL.stringify(expected, options)).toBe(text);
+});
+
 test.each([undefined])("JsonURL.parse(%p)", (text) => {
   expect(u.parse(text)).toBeUndefined();
 });

--- a/test/parseLiteral.test.js
+++ b/test/parseLiteral.test.js
@@ -37,7 +37,9 @@ function encodedString(s) {
 function runTest(text, value, keyValue, strLitValue) {
   expect(u.parseLiteral(text)).toBe(value);
   expect(u.parseLiteral(text, 0, text.length, true)).toBe(keyValue);
-  expect(u.parseLiteral(text, 0, text.length, true, true)).toBe(strLitValue);
+  expect(
+    u.parseLiteral(text, 0, text.length, true, { impliedStringLiterals: true })
+  ).toBe(strLitValue);
 
   //
   // verify that parseLiteral() and parse() return the same thing (as

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -32,10 +32,24 @@ test("JsonURL.stringify(undefined)", () => {
   expect(JsonURL.stringify(undefined)).toBeUndefined();
 });
 
+test("JsonURL.stringify(null, impliedStringLiterals)", () => {
+  expect(() => {
+    JsonURL.stringify(null, { impliedStringLiterals: true });
+  }).toThrow(SyntaxError);
+});
+
+test("JsonURL.stringify('', impliedStringLiterals)", () => {
+  expect(() => {
+    JsonURL.stringify("", {
+      impliedStringLiterals: true,
+      allowEmptyUnquotedValues: false,
+    });
+  }).toThrow(SyntaxError);
+});
+
 test.each([
   [true, "true", "true"],
   [false, "false", "false"],
-  [null, "null", "null"],
   ["true", "'true'", "true"],
   ["false", "'false'", "false"],
   ["null", "'null'", "null"],
@@ -62,6 +76,7 @@ test.each([
   ["   ", "+++", "+++"],
   ["Bob & Frank", "Bob+%26+Frank", "Bob+%26+Frank"],
   ["'hello", "%27hello", "'hello"],
+  [1e5, "100000", "100000"],
 ])("JsonURL.stringify(%p)", (value, expected, expectedISL) => {
   expect(JsonURL.stringify(value)).toBe(expected);
 
@@ -83,6 +98,15 @@ test.each([
     { ignoreUndefinedObjectMembers: false },
     "a:null,b:1",
   ],
+  [{ "": "a", b: 1 }, { allowEmptyUnquotedKeys: true }, ":a,b:1"],
+  [{ a: "", b: 1 }, { allowEmptyUnquotedValues: true }, "a:,b:1"],
+  [["a", "", "b"], { allowEmptyUnquotedValues: true }, "a,,b"],
+  [
+    { a: "", b: "1", c: "false", d: "true" },
+    { impliedStringLiterals: true },
+    "a:,b:1,c:false,d:true",
+  ],
+  [["a", "", "b"], { impliedStringLiterals: true }, "a,,b"],
   [
     { a: 1, b: 2, c: { d: 4, e: 5 } },
     { wwwFormUrlEncoded: true },


### PR DESCRIPTION
Two new options are included in the options for parse() and stringify()
to control the behaviour:

options.allowEmptyUnquotedValues
options.allowEmptyUnquotedKeys
