### PR TITLE
chore: Add a couple stringify tests

### DIFF
--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -38,6 +38,15 @@ test("JsonURL.stringify(null, impliedStringLiterals)", () => {
   }).toThrow(SyntaxError);
 });
 
+test("JsonURL.stringify(null, coerce+impliedString)", () => {
+  expect(
+    JsonURL.stringify(null, {
+      coerceNullToEmptyString: true,
+      impliedStringLiterals: true,
+    })
+  ).toBe("");
+});
+
 test("JsonURL.stringify('', impliedStringLiterals)", () => {
   expect(() => {
     JsonURL.stringify("", {
@@ -50,6 +59,8 @@ test("JsonURL.stringify('', impliedStringLiterals)", () => {
 test.each([
   [true, "true", "true"],
   [false, "false", "false"],
+  [{}, "()", "()"],
+  [[], "()", "()"],
   ["true", "'true'", "true"],
   ["false", "'false'", "false"],
   ["null", "'null'", "null"],


### PR DESCRIPTION
Added tests to verify the stringify result of empty array and empty
object. By default this should return the empty composite value.

Added a test to check that stringify returns the empty string for the
null literal value when options.coerceNullToEmptyString and
options.impliedStringLiterals are both true.