### PR TITLE
fix: Fix bug stringifying number-like AQF strings that include plus

### DIFF
--- a/src/JsonURL.js
+++ b/src/JsonURL.js
@@ -271,7 +271,10 @@ function toJsonURLText_String(options, depth, isKey) {
       return this;
     }
     if (options.AQF) {
-      return "!" + this;
+      if (this.indexOf("+") == -1) {
+        return "!" + this;
+      }
+      return this.replace("+", "!+");
     }
     if (this.indexOf("+") == -1) {
       return "'" + this + "'";

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -83,7 +83,7 @@ test.each([
   ["-4", "'-4'", "-4", "!-4"],
   ["5a", undefined, undefined, undefined],
   ["'1+2'", "%271%2B2'", "'1%2B2'", undefined],
-  ["1e+1", "1e%2B1", undefined, "!1e+1"],
+  ["1e+1", "1e%2B1", undefined, "1e!+1"],
   ["a b c", "a+b+c", undefined, undefined],
   ["a,b", "'a,b'", "a%2Cb", "a!,b"],
   ["a,b c", "'a,b+c'", "a%2Cb+c", "a!,b+c"],


### PR DESCRIPTION
A string like "1e+6" must be represented as 1e!+6, where the plus is
escaped. Otherwise, the plus will be read as a space when it's later
parsed.