### PR TITLE
feat: ignore null array/object member parse option

### DIFF
--- a/jsonurl.d.ts
+++ b/jsonurl.d.ts
@@ -232,6 +232,16 @@ type JsonURLStringifyOptions = {
      * number of values. The default is 4096.
      */
     maxParseValues?: number,
+    /**
+     * @type {boolean} [ignoreNullArrayMembers=false] Ignore null array
+     * members.
+     */
+    ignoreNullArrayMembers?: boolean,
+    /**
+     * @type {boolean} [ignoreNullObjectMembers=false] Ignore null object
+     * members.
+     */
+    ignoreNullObjectMembers?: boolean,
   }
   
   declare class JsonURL {

--- a/src/JsonURLOptions.js
+++ b/src/JsonURLOptions.js
@@ -39,6 +39,8 @@ export class JsonURLOptions {
     this.setOrDefault(src, "allowEmptyUnquotedKeys");
     this.setOrDefault(src, "AQF");
     this.setOrDefault(src, "coerceNullToEmptyString");
+    this.setOrDefault(src, "ignoreNullArrayMembers");
+    this.setOrDefault(src, "ignoreNullObjectMembers");
     this.setOrDefault(src, "impliedArray");
     this.setOrDefault(src, "impliedObject");
     this.setOrDefault(src, "impliedStringLiterals");
@@ -80,5 +82,12 @@ export class JsonURLOptions {
       key,
       defValue === undefined ? defValue : parseInt(defValue)
     );
+  }
+
+  /**
+   * Evaluates to true if the given `ignore` option is present and truthy.
+   */
+  isPresentAndTrue(key) {
+    return key in this && this[key];
   }
 }

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -141,6 +141,10 @@ test.each([
     { coerceNullToEmptyString: true },
     { a: "", null: "d", e: "f" },
   ],
+  ["(a:b,c:null)", { ignoreNullObjectMembers: true }, { a: "b" }],
+  ["(a:null,b:c)", { ignoreNullObjectMembers: true }, { b: "c" }],
+  ["(a,null,c)", { ignoreNullArrayMembers: true }, ["a", "c"]],
+  ["(a,b,null)", { ignoreNullArrayMembers: true }, ["a", "b"]],
 ])("JsonURL.parse(%s,%p)", (text, options, expected) => {
   expect(u.parse(text, options)).toEqual(expected);
   expect(parseAQF(text, options)).toEqual(expected);


### PR DESCRIPTION
Add support for the ignoreNullObjectMembers and ignoreNullObjectMembers options to JsonURL.parse().