### PR TITLE
build(deps-dev): Drop build support for node 12, add node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Set artifact version
       run: script/version_snapshot.sh
       shell: bash
-    - name: Use Node.js 16.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v2
       with:
-        node-version: 16.x
+        node-version: 18.x
     - name: Cache Node.js modules
       timeout-minutes: 10
       uses: actions/cache@v2
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Node.js  ${{ matrix.node-version }}
@@ -103,10 +103,10 @@ jobs:
     - name: Set artifact version
       run: script/version_snapshot.sh
       shell: bash
-    - name: Use Node.js 16.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v2
       with:
-        node-version: 16.x
+        node-version: 18.x
     - name: Cache Node.js modules
       timeout-minutes: 10
       uses: actions/cache@v2


### PR DESCRIPTION
This patch modifies the CI build pipeline to drop support for node 12 and add support for node 18 because Jest 29.x requires node >=14.x.