### PR TITLE
fix: Fix bug stringifying number-like keys and values

### DIFF
--- a/test/parseLiteral.test.js
+++ b/test/parseLiteral.test.js
@@ -45,13 +45,12 @@ function escapeStringAQF(s) {
     .replace(/:/, "!:");
 }
 
-function runTest(text, value, keyValue, strLitValue) {
+function runTest(text, value, keyValue, impliedStrValue) {
   expect(u.parseLiteral(text)).toBe(value);
-  expect(JsonURL.parse(text)).toBe(value);
   expect(u.parseLiteral(text, 0, text.length, true)).toBe(keyValue);
   expect(
     u.parseLiteral(text, 0, text.length, true, { impliedStringLiterals: true })
-  ).toBe(strLitValue);
+  ).toBe(impliedStrValue);
 
   //
   // verify that parseLiteral() and parse() return the same thing (as
@@ -61,10 +60,10 @@ function runTest(text, value, keyValue, strLitValue) {
   expect(JsonURL.parse(text)).toBe(value);
 }
 
-function runTestAQF(text, value, strLitValue) {
+function runTestAQF(text, value, impliedStrValue) {
   expect(u.parse(text, { AQF: true })).toBe(value);
   expect(u.parse(text, { AQF: true, impliedStringLiterals: true })).toBe(
-    strLitValue
+    impliedStrValue
   );
 }
 
@@ -147,7 +146,6 @@ test.each([
   runTestAQF(textAQF, value, keyValue);
 });
 
-// eslint-disable-next-line jest/expect-expect
 test.each([
   //
   // fixed point
@@ -155,6 +153,8 @@ test.each([
   ["-3e0", -3, undefined, "-3e0"],
   ["1e+2", 1e2, undefined, "1e 2"],
   ["-2e+1", -2e1, undefined, "-2e 1"],
+  ["1e-2", 1e-2, undefined, "1e-2"],
+  ["1e+2", 1e2, undefined, "1e 2"],
 
   //
   // floating point
@@ -164,25 +164,32 @@ test.each([
   //
   // string
   //
-  ["'hello'", "hello", "'hello'", undefined],
+  ["'hello'", "hello", "'hello'", "'hello'"],
   ["hello%2Bworld", "hello+world", undefined, undefined],
   ["y+%3D+mx+%2B+b", "y = mx + b", undefined, undefined],
   ["a%3Db%26c%3Dd", "a=b&c=d", undefined, undefined],
   ["hello%F0%9F%8D%95world", "hello\uD83C\uDF55world", undefined, undefined],
   ["-e+", "-e ", undefined, undefined],
   ["-e+1", "-e 1", undefined, undefined],
-  ["1e%2B1", "1e+1", 10, "1e+1"],
+  ["1e%2B1", "1e+1", "1e+1", "1e+1"],
   ["%26true", "&true", undefined, undefined],
-])("JsonURL.parseLiteral(%p)", (text, value, aqfValue, strLitValue) => {
+])("JsonURL.parseLiteral(%p)", (text, value, aqfValue, impliedStrValue) => {
   let keyValue = typeof value === "string" ? value : text;
   if (aqfValue === undefined) {
     aqfValue = value;
   }
-  if (strLitValue === undefined) {
-    strLitValue = aqfValue;
-  }
-  runTest(text, value, keyValue, strLitValue);
-  runTestAQF(text, aqfValue, strLitValue);
+
+  runTest(
+    text,
+    value,
+    keyValue,
+    impliedStrValue === undefined ? keyValue : impliedStrValue
+  );
+
+  expect(u.parse(text, { AQF: true })).toBe(aqfValue);
+  expect(u.parse(text, { AQF: true, impliedStringLiterals: true })).toBe(
+    impliedStrValue === undefined ? aqfValue : impliedStrValue
+  );
 });
 
 test("JsonURL.parseLiteral('null')", () => {

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -82,7 +82,7 @@ test.each([
   ["2e1", "'2e1'", "2e1", "!2e1"],
   ["-4", "'-4'", "-4", "!-4"],
   ["5a", undefined, undefined, undefined],
-  ["'1+2'", "%271%2B2'", "'1%2B2'", undefined],
+  ["'1+2'", "%271%2B2'", "'1%2B2'", "'1!+2'"],
   ["1e+1", "1e%2B1", undefined, "1e!+1"],
   ["a b c", "a+b+c", undefined, undefined],
   ["a,b", "'a,b'", "a%2Cb", "a!,b"],
@@ -200,3 +200,78 @@ test("JsonURL.stringify(instance specific toJsonURLText function)", () => {
 
   expect(JsonURL.stringify(filter)).toBe("(filter:color,value:red)");
 });
+
+test.each([
+  //
+  // string
+  //
+  [
+    "1e+3",
+    "1e%2B3",
+    "1e!+3",
+    "1e%2B3",
+    "1e!+3",
+    "1e%2B3",
+    "1e%2B3",
+    "1e!+3",
+    "1e!+3",
+  ],
+  [
+    "1e 3",
+    "'1e+3'",
+    "!1e+3",
+    "1e+3",
+    "1e+3",
+    "'1e+3'",
+    "1e+3",
+    "!1e+3",
+    "1e+3",
+  ],
+])(
+  "JsonURL.stringifyLiteralAndKey(%p)",
+  (
+    text,
+    expectedKey,
+    expectedKeyAqf,
+    expectedKeyIsl,
+    expectedKeyIslAqf,
+    expected,
+    expectedImpliedStringLiteral,
+    expectedAqf,
+    expectedImpliedStringAqf
+  ) => {
+    function makeObject(s) {
+      const ret = {};
+      ret[s] = 1;
+      return ret;
+    }
+    function makeText(s) {
+      return "(" + s + ":1)";
+    }
+
+    expect(JsonURL.stringify(makeObject(text))).toEqual(makeText(expectedKey));
+    expect(JsonURL.stringify(makeObject(text), { AQF: true })).toEqual(
+      makeText(expectedKeyAqf)
+    );
+    expect(
+      JsonURL.stringify(makeObject(text), {
+        impliedStringLiterals: true,
+      })
+    ).toEqual(makeText(expectedKeyIsl));
+    expect(
+      JsonURL.stringify(makeObject(text), {
+        AQF: true,
+        impliedStringLiterals: true,
+      })
+    ).toEqual(makeText(expectedKeyIslAqf));
+
+    expect(JsonURL.stringify(text)).toBe(expected);
+    expect(JsonURL.stringify(text, { impliedStringLiterals: true })).toBe(
+      expectedImpliedStringLiteral
+    );
+    expect(JsonURL.stringify(text, { AQF: true })).toBe(expectedAqf);
+    expect(
+      JsonURL.stringify(text, { AQF: true, impliedStringLiterals: true })
+    ).toBe(expectedImpliedStringAqf);
+  }
+);


### PR DESCRIPTION
A string like "1e 6" will currently be stringified as 1e+6, which is ambiguous because it looks like a number literal and it will be parsed as one. This patch fixes the stringify code so that these strings are quoted. AQF strings have a similar issue and this patch addresses them as well.