### PR TITLE
fix: Next.js error with redefine toJsonURLText

### DIFF
--- a/src/proto.js
+++ b/src/proto.js
@@ -31,18 +31,23 @@ export function setupToJsonURLText({
 }) {
   Object.defineProperty(Array.prototype, "toJsonURLText", {
     value: toJsonURLText_Array,
+    configurable: true,
   });
   Object.defineProperty(Boolean.prototype, "toJsonURLText", {
     value: toJsonURLText_Boolean,
+    configurable: true,
   });
   Object.defineProperty(Number.prototype, "toJsonURLText", {
     value: toJsonURLText_Number,
+    configurable: true,
   });
   Object.defineProperty(Object.prototype, "toJsonURLText", {
     value: toJsonURLText_Object,
+    configurable: true,
   });
   Object.defineProperty(String.prototype, "toJsonURLText", {
     value: toJsonURLText_String,
+    configurable: true,
   });
 }
 


### PR DESCRIPTION
Library not correct work in Next.js. This PR fix it
```
 ⨯ TypeError: Cannot redefine property: toJsonURLText
    at Object.defineProperty (<anonymous>)
    at __TURBOPACK__module__evaluation__ (src/common/utils/search-params.ts:3:1)
    at __TURBOPACK__module__evaluation__ (src/common/hooks/use-search-params-state.ts:5:1)
    at __TURBOPACK__module__evaluation__ (src/common/hooks/use-app-search-params.ts:3:1)
    at __TURBOPACK__module__evaluation__ (src/features/article/pages/articles-page.tsx:13:1)
> 1 | import JsonURL from "@jsonurl/jsonurl";
```